### PR TITLE
Clean up code and use 1 item instead of whole stack

### DIFF
--- a/src/main/java/cz/sycha/hattie/Main.java
+++ b/src/main/java/cz/sycha/hattie/Main.java
@@ -20,11 +20,17 @@ public class Main extends JavaPlugin {
         Player player = (Player) sender;
 
         PlayerInventory inv = player.getInventory();
-        ItemStack itemToUse = inv.getItemInMainHand();
+        ItemStack itemToUse = inv.getItemInMainHand().clone();
+        itemToUse.setAmount(1);
         ItemStack oldItem = inv.getHelmet();
 
         inv.setHelmet(itemToUse);
-        inv.remove(itemToUse);
+        if (inv.getItemInMainHand().getAmount() > 1) {
+        	inv.getItemInMainHand().setAmount(inv.getItemInMainHand().getAmount() - 1);
+        }
+        else {
+        	inv.setItemInMainHand(null);
+        }
         if (oldItem != null) inv.addItem(new ItemStack[] { oldItem });
 
         player.sendMessage(ChatColor.AQUA + "The item in your hand has been put on your head!");

--- a/src/main/java/cz/sycha/hattie/Main.java
+++ b/src/main/java/cz/sycha/hattie/Main.java
@@ -26,7 +26,7 @@ public class Main extends JavaPlugin {
 
             inv.setHelmet(itemToUse);
             inv.remove(itemToUse);
-            inv.addItem(new ItemStack[] { oldItem });
+            if (oldItem != null) inv.addItem(new ItemStack[] { oldItem });
 
             player.sendMessage(ChatColor.AQUA + "The item in your hand has been put on your head!");
 

--- a/src/main/java/cz/sycha/hattie/Main.java
+++ b/src/main/java/cz/sycha/hattie/Main.java
@@ -19,19 +19,16 @@ public class Main extends JavaPlugin {
 
         Player player = (Player) sender;
 
-        if(command.getName().equalsIgnoreCase("hat") && sender.hasPermission("hattie.use")) {
-            PlayerInventory inv = player.getInventory();
-            ItemStack itemToUse = inv.getItemInMainHand();
-            ItemStack oldItem = inv.getHelmet();
+        PlayerInventory inv = player.getInventory();
+        ItemStack itemToUse = inv.getItemInMainHand();
+        ItemStack oldItem = inv.getHelmet();
 
-            inv.setHelmet(itemToUse);
-            inv.remove(itemToUse);
-            if (oldItem != null) inv.addItem(new ItemStack[] { oldItem });
+        inv.setHelmet(itemToUse);
+        inv.remove(itemToUse);
+        if (oldItem != null) inv.addItem(new ItemStack[] { oldItem });
 
-            player.sendMessage(ChatColor.AQUA + "The item in your hand has been put on your head!");
+        player.sendMessage(ChatColor.AQUA + "The item in your hand has been put on your head!");
 
-            return true;
-        }
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
Tried out the plugin and noticed a few issues:
- If the player didn't already have a helmet when using `/hat`, it would throw a `NullPointerException`. I don't think this broke the plugin, but I added a null check just to be safe.
- Since the `plugin.yml` file already outlines the command, as well as the permission required for it, and since there's only one command used by the plugin, there's no need to check the command name or if the player has permission to use it as it's handled by Spigot already.
- Using `/hat` now only takes one item from the held stack.
